### PR TITLE
Expand experiment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ classes for five scoring strategies:
 * **NLI** – entailment check via substring matching.
 * **LLM Prompt** – ask an external model whether a sentence is supported.
 
-A small demonstration script `run_experiments.py` evaluates the n‑gram
-metric on a subset of the WikiBio hallucination dataset.
+The `run_experiments.py` script can evaluate any of the simplified
+metrics on a slice of the WikiBio hallucination dataset.  It mirrors the
+evaluation loop of the original project but uses light‑weight stand‑ins so
+that the code runs in restricted environments.
 
 ## Installation
 
@@ -23,10 +25,19 @@ metric on a subset of the WikiBio hallucination dataset.
 pip install -r requirements.txt
 ```
 
-## Running the example experiment
+## Running experiments
+
+By default the script evaluates the n‑gram metric on fifty examples:
 
 ```bash
 python run_experiments.py
+```
+
+To score several metrics at once specify them via ``--metrics`` and
+optionally change the number of evaluated examples with ``--limit``:
+
+```bash
+python run_experiments.py --metrics ngram mqag nli --limit 25
 ```
 
 ## Running tests

--- a/run_experiments.py
+++ b/run_experiments.py
@@ -1,48 +1,115 @@
-"""Minimal evaluation script for the simplified SelfCheckGPT metrics.
+"""Run simple experiments with the toy SelfCheckGPT metrics.
 
-This script is intentionally lightweight.  It loads a small portion of
-`potsawee/wiki_bio_gpt3_hallucination` and evaluates the simplified
-``SelfCheckNgram`` metric.  The goal is to demonstrate how the metrics
-may be invoked rather than to reproduce the exact numbers from the paper.
+The original :mod:`selfcheckgpt` project evaluates several different
+hallucination detectors.  The earlier version of this repository only
+demonstrated the n‑gram variant.  This script offers a slightly more
+flexible evaluation loop that can score multiple metrics on a slice of
+the ``potsawee/wiki_bio_gpt3_hallucination`` dataset.  The
+implementations are still intentionally lightweight but the structure of
+the experiment is closer to the setup described in the paper.
 """
 
+from __future__ import annotations
+
+import argparse
 import logging
-from typing import List
+from typing import Callable, Dict, Iterable, List
 
 from datasets import load_dataset
 from sklearn.metrics import average_precision_score
 
-from selfcheck_metrics import SelfCheckNgram
+from selfcheck_metrics import (
+    SelfCheckBERTScore,
+    SelfCheckMQAG,
+    SelfCheckNLI,
+    SelfCheckNgram,
+    SelfCheckPrompt,
+)
 
 logging.basicConfig(level=logging.INFO)
 
 
 def load_annotations(example) -> List[int]:
-    """Convert annotation strings to binary non-factual labels."""
-    labels = []
+    """Convert annotation strings to binary non‑factual labels."""
+
+    labels: List[int] = []
     for ann in example["annotation"]:
         labels.append(0 if ann == "accurate" else 1)
     return labels
 
 
-def main() -> None:
-    logging.info("Loading dataset ...")
-    ds = load_dataset("potsawee/wiki_bio_gpt3_hallucination", split="test[:5]")
+# ---------------------------------------------------------------------------
+# Metric factory ------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
-    logging.info("Evaluating SelfCheckNgram on a handful of samples ...")
-    metric = SelfCheckNgram()
+def _prompt_heuristic(context: str, sentence: str) -> str:
+    """Very small stand‑in for the real LLM prompt call.
+
+    The function simply checks whether the final token of ``sentence``
+    appears in ``context`` and returns "Yes" or "No" accordingly.  This
+    keeps the example runnable without external API access.
+    """
+
+    token = sentence.split()[-1].strip(". ,") if sentence.split() else ""
+    return "Yes" if token and token in context else "No"
+
+
+MetricFactory = Dict[str, Callable[[], object]]
+
+METRICS: MetricFactory = {
+    "bertscore": lambda: SelfCheckBERTScore(use_bert_score=False),
+    "mqag": SelfCheckMQAG,
+    "ngram": SelfCheckNgram,
+    "nli": SelfCheckNLI,
+    "prompt": lambda: SelfCheckPrompt(ask_fn=_prompt_heuristic),
+}
+
+
+def evaluate(metric, dataset: Iterable[dict]) -> float:
+    """Return average precision of ``metric`` on ``dataset``."""
+
     all_scores: List[float] = []
     all_labels: List[int] = []
-    for example in ds:
+    for example in dataset:
         sentences = example["gpt3_sentences"]
         samples = example["gpt3_text_samples"]
         scores = metric.predict(sentences, samples)
         labels = load_annotations(example)
         all_scores.extend(scores)
         all_labels.extend(labels)
+    return average_precision_score(all_labels, all_scores)
 
-    ap = average_precision_score(all_labels, all_scores)
-    logging.info("Average precision: %.3f", ap)
+
+def main() -> None:  # pragma: no cover - exercised via CLI
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--metrics",
+        nargs="+",
+        default=["ngram"],
+        help="Which metrics to evaluate (or 'all').",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Number of test examples to load from the dataset.",
+    )
+    args = parser.parse_args()
+
+    metric_names = list(METRICS) if "all" in args.metrics else args.metrics
+
+    logging.info("Loading dataset slice of %d examples ...", args.limit)
+    ds = load_dataset(
+        "potsawee/wiki_bio_gpt3_hallucination", split=f"test[:{args.limit}]"
+    )
+
+    for name in metric_names:
+        if name not in METRICS:
+            logging.warning("Unknown metric '%s' -- skipping", name)
+            continue
+        metric = METRICS[name]()
+        ap = evaluate(metric, ds)
+        logging.info("%s average precision: %.3f", name, ap)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend `run_experiments.py` to evaluate multiple simplified SelfCheckGPT metrics with CLI options
- add lightweight prompt heuristic for demo LLM-prompt scoring
- document multi-metric experiments in README

## Testing
- `pytest -q`
- `python run_experiments.py --metrics all --limit 5` *(fails: Couldn't reach 'potsawee/wiki_bio_gpt3_hallucination' on the Hub (ProxyError))*

------
https://chatgpt.com/codex/tasks/task_e_6894f44010cc8325b609a1efc26da363