### PR TITLE
Add T5-based question generation and QA scoring

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ scikit-learn
 datasets
 openai
 pytest
+transformers
+torch
+sentencepiece

--- a/tests/test_selfcheck_metrics.py
+++ b/tests/test_selfcheck_metrics.py
@@ -45,6 +45,20 @@ def test_mqag_last_token():
     assert math.isclose(score, 0.0)
 
 
+def test_mqag_qg_qa_scoring():
+    def fake_qg(sentence: str) -> str:
+        return "What does John love?"
+
+    def fake_qa(question: str, context: str) -> str:
+        return "pizza" if "pizza" in context else "unknown"
+
+    metric = SelfCheckMQAG(qg_fn=fake_qg, qa_fn=fake_qa)
+    sents = ["John loves pizza"]
+    samples = ["Yesterday John ate pizza", "John prefers pasta"]
+    score = metric.predict(sents, samples)[0]
+    assert math.isclose(score, 0.5)
+
+
 def test_prompt_mapping_yes_no():
     def fake_ask(context: str, sentence: str) -> str:
         return "Yes" if "earth" in context else "No"


### PR DESCRIPTION
## Summary
- integrate optional T5 question generation and DistilBERT QA into `SelfCheckMQAG`
- allow custom QG/QA functions with fallback heuristic
- expand MQAG tests and add transformers dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895053bca988325a5bfb565627ccd49