### PR TITLE
Use OpenAI prompts with throttling and robust tests

### DIFF
--- a/run_experiments.py
+++ b/run_experiments.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 from typing import Callable, Dict, Iterable, List
 
 from datasets import load_dataset
@@ -42,16 +43,16 @@ def load_annotations(example) -> List[int]:
 # Metric factory ------------------------------------------------------------
 # ---------------------------------------------------------------------------
 
+_PROMPT_CLIENT = SelfCheckPrompt(
+    api_key=os.getenv("OPENAI_API_KEY", ""),
+    rate_limit=float(os.getenv("OPENAI_RATE_LIMIT", "1.0")),
+)
+
+
 def _prompt_heuristic(context: str, sentence: str) -> str:
-    """Very small stand‑in for the real LLM prompt call.
+    """Proxy that delegates to the real OpenAI prompt call."""
 
-    The function simply checks whether the final token of ``sentence``
-    appears in ``context`` and returns "Yes" or "No" accordingly.  This
-    keeps the example runnable without external API access.
-    """
-
-    token = sentence.split()[-1].strip(". ,") if sentence.split() else ""
-    return "Yes" if token and token in context else "No"
+    return _PROMPT_CLIENT._openai_ask(context, sentence)
 
 
 MetricFactory = Dict[str, Callable[[], object]]

--- a/selfcheck_metrics.py
+++ b/selfcheck_metrics.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 from typing import Callable, Iterable, List
 import collections
 import math
+import os
+import time
 
 
 # ---------------------------------------------------------------------------
@@ -146,26 +148,55 @@ class SelfCheckPrompt:
 
     The constructor accepts an ``ask_fn`` callable used to query the LLM.
     This makes the class easy to test as the heavy API call can be
-    replaced with a stub.
+    replaced with a stub.  ``api_key`` and ``rate_limit`` parameters
+    provide configurable access to real APIs.
     """
 
-    def __init__(self, ask_fn: Callable[[str, str], str] | None = None) -> None:
+    def __init__(
+        self,
+        ask_fn: Callable[[str, str], str] | None = None,
+        api_key: str | None = None,
+        rate_limit: float = 1.0,
+        max_retries: int = 2,
+    ) -> None:
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY", "")
+        self.rate_limit = rate_limit
+        self.max_retries = max_retries
         self.ask_fn = ask_fn or self._openai_ask
+        self._last_call = 0.0
 
     # -- Actual API call -----------------------------------------------------
-    def _openai_ask(self, context: str, sentence: str) -> str:  # pragma: no cover - requires network
-        import openai
+    def _openai_ask(self, context: str, sentence: str) -> str:
+        """Query the OpenAI API with basic throttling."""  # pragma: no cover - requires network
+
+        try:
+            import openai
+            from openai.error import OpenAIError
+        except Exception:
+            return "Unknown"
+
+        openai.api_key = self.api_key or openai.api_key
 
         prompt = (
             f"Context: {context}\nSentence: {sentence}\n"
             "Is the sentence supported by the context above?\nAnswer Yes or No:"
         )
-        res = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": prompt}],
-            temperature=0,
-        )
-        return res["choices"][0]["message"]["content"].strip()
+
+        for _ in range(self.max_retries):
+            delay = self.rate_limit - (time.time() - self._last_call)
+            if delay > 0:
+                time.sleep(delay)
+            self._last_call = time.time()
+            try:
+                res = openai.ChatCompletion.create(
+                    model="gpt-3.5-turbo",
+                    messages=[{"role": "user", "content": prompt}],
+                    temperature=0,
+                )
+                return res["choices"][0]["message"]["content"].strip()
+            except OpenAIError:
+                time.sleep(self.rate_limit)
+        return "Unknown"
 
     def predict(self, sentences: Iterable[str], samples: Iterable[str]) -> List[float]:
         samples = list(samples)

--- a/tests/test_selfcheck_metrics.py
+++ b/tests/test_selfcheck_metrics.py
@@ -1,5 +1,6 @@
 import math
 import sys
+import types
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -54,3 +55,45 @@ def test_prompt_mapping_yes_no():
     samples = ["Observation shows the earth is round.", "The moon orbits"]
     score = metric.predict(sents, samples)[0]
     assert score == 0.5  # one yes and one no
+
+
+def test_prompt_openai_mocked(monkeypatch):
+    calls = iter(["Yes", "No"])
+
+    def fake_create(**kwargs):
+        return {"choices": [{"message": {"content": next(calls)}}]}
+
+    error_module = types.SimpleNamespace(OpenAIError=Exception)
+    openai_module = types.SimpleNamespace(
+        ChatCompletion=types.SimpleNamespace(create=fake_create),
+        api_key="",
+        error=error_module,
+    )
+    monkeypatch.setitem(sys.modules, "openai", openai_module)
+    monkeypatch.setitem(sys.modules, "openai.error", error_module)
+
+    metric = SelfCheckPrompt(api_key="test", rate_limit=0.0)
+    sents = ["The earth is round."]
+    samples = ["Observation shows the earth is round.", "The moon orbits"]
+    score = metric.predict(sents, samples)[0]
+    assert score == 0.5
+
+
+def test_prompt_openai_error(monkeypatch):
+    def fake_create(**kwargs):
+        raise Exception("rate limit")
+
+    error_module = types.SimpleNamespace(OpenAIError=Exception)
+    openai_module = types.SimpleNamespace(
+        ChatCompletion=types.SimpleNamespace(create=fake_create),
+        api_key="",
+        error=error_module,
+    )
+    monkeypatch.setitem(sys.modules, "openai", openai_module)
+    monkeypatch.setitem(sys.modules, "openai.error", error_module)
+
+    metric = SelfCheckPrompt(api_key="test", rate_limit=0.0, max_retries=1)
+    sents = ["The earth is round."]
+    samples = ["Observation shows the earth is round."]
+    score = metric.predict(sents, samples)[0]
+    assert score == 0.5


### PR DESCRIPTION
## Summary
- Replace toy token heuristic with real OpenAI-backed prompt call in `run_experiments`
- Extend `SelfCheckPrompt` with configurable API key, retry-based throttling and graceful error handling
- Add tests that mock OpenAI responses and failure modes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689505448fd083258d417c60323d5b02