### PR TITLE
Add dataset utilities and resource setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,13 @@ that the code runs in restricted environments.
 
 ## Installation
 
+The project relies on the WikiBio hallucination dataset and spaCy's English
+model. After installing the Python dependencies, download these resources:
+
 ```bash
 pip install -r requirements.txt
+python -m spacy download en_core_web_sm
+python -c "from data.utils import load_wikibio_hallucination; load_wikibio_hallucination(split='train[:1]')"
 ```
 
 ## Running experiments

--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,0 +1,1 @@
+"""Data utilities package."""

--- a/data/utils.py
+++ b/data/utils.py
@@ -1,0 +1,42 @@
+"""Helpers for loading and validating datasets used by the project."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+from datasets import Dataset, load_dataset
+
+DATASET_NAME = "hallucinations/wikibio"
+DEFAULT_CACHE_DIR = Path.home() / ".cache" / "selfcheckgpt"
+
+
+def load_wikibio_hallucination(
+    split: str = "train",
+    cache_dir: Union[str, Path] = DEFAULT_CACHE_DIR,
+) -> Dataset:
+    """Download and return a slice of the WikiBio hallucination dataset.
+
+    The dataset is cached locally so subsequent calls are fast.
+
+    Args:
+        split: Dataset split to load. Supports slice notation such as
+            ``"train[:1]"`` for a tiny sample used in tests.
+        cache_dir: Directory where the dataset will be cached.
+
+    Returns:
+        A :class:`datasets.Dataset` containing the requested split.
+    """
+    cache_path = Path(cache_dir)
+    cache_path.mkdir(parents=True, exist_ok=True)
+    dataset = load_dataset(DATASET_NAME, split=split, cache_dir=str(cache_path))
+    _validate_dataset(dataset)
+    return dataset
+
+
+def _validate_dataset(dataset: Dataset) -> None:
+    """Basic validation to ensure the dataset is usable."""
+    if len(dataset) == 0:
+        raise ValueError("Loaded dataset split is empty")
+    if not dataset.column_names:
+        raise ValueError("Dataset has no columns")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ pytest
 transformers
 torch
 sentencepiece
+bert-score
+spacy
+sentence-transformers

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -1,0 +1,24 @@
+import pathlib
+import sys
+
+import spacy
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from data.utils import load_wikibio_hallucination
+
+
+def test_spacy_model_loads():
+    nlp = spacy.load("en_core_web_sm")
+    doc = nlp("This is a test.")
+    assert doc.text == "This is a test."
+
+
+def test_wikibio_dataset_loads(tmp_path):
+    try:
+        ds = load_wikibio_hallucination(
+            split="train[:1]", cache_dir=tmp_path
+        )
+    except Exception as exc:  # pragma: no cover - network failure
+        pytest.skip(f"dataset download failed: {exc}")
+    assert len(ds) == 1


### PR DESCRIPTION
## Summary
- add WikiBio dataset loader with caching and validation
- document downloading spaCy model and dataset
- include smoke tests for spaCy model and dataset access

## Testing
- `python -m spacy download en_core_web_sm`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68950dcb07ac8325835b5370f2039e08