### PR TITLE
Add DeBERTa-based NLI scorer and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ classes for five scoring strategies:
 * **BERTScore** – semantic similarity to sampled passages.
 * **MQAG** – a tiny proxy for question answering consistency.
 * **n‑gram** – unigram language model scoring.
-* **NLI** – entailment check via substring matching.
+* **NLI** – entailment check using a pretrained NLI model.
 * **LLM Prompt** – ask an external model whether a sentence is supported.
 
 The `run_experiments.py` script can evaluate any of the simplified

--- a/tests/test_selfcheck_metrics.py
+++ b/tests/test_selfcheck_metrics.py
@@ -68,12 +68,18 @@ def test_ngram_trigram():
     assert scores[1] > scores[0]
 
 
-def test_nli_substring():
-    metric = SelfCheckNLI()
-    sents = ["Paris is in France."]
+def test_nli_entailment_and_contradiction():
+    def fake_nli(premise: str, hypothesis: str) -> tuple[float, float]:
+        if "France" in premise and "France" in hypothesis:
+            return 0.01, 0.95  # entailed
+        return 0.9, 0.05  # contradiction
+
+    metric = SelfCheckNLI(nli_fn=fake_nli)
+    sents = ["Paris is in France.", "Paris is in Spain."]
     samples = ["Paris is in France. It is a city."]
-    score = metric.predict(sents, samples)[0]
-    assert score == 0.0
+    scores = metric.predict(sents, samples)
+    assert scores[0] < 0.1  # entailed
+    assert scores[1] > 0.9  # contradiction
 
 
 def test_mqag_answerable_and_unanswerable():


### PR DESCRIPTION
## Summary
- Implement `SelfCheckNLI` using a pretrained DeBERTa MNLI model
- Compute inconsistency from contradiction and entailment probabilities
- Test NLI behaviour with stubbed probabilities
- Update README to document new NLI approach

## Testing
- `python -m spacy download en_core_web_sm`
- `pytest -q`