### PR TITLE
Add generator for deterministic LLM sampling

### DIFF
--- a/sampling/generator.py
+++ b/sampling/generator.py
@@ -1,0 +1,38 @@
+"""Utilities for generating and storing samples from an LLM."""
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from typing import Iterable, Protocol
+
+
+class LLM(Protocol):
+    """Protocol for language model clients."""
+
+    def __call__(self, prompt: str, *, temperature: float) -> str:  # pragma: no cover - interface
+        """Generate a completion for ``prompt``."""
+
+
+def generate_samples(
+    llm: LLM,
+    prompts: Iterable[str],
+    output_path: str | Path,
+    *,
+    num_samples: int = 1,
+    temperature: float = 0.7,
+) -> None:
+    """Query ``llm`` for each prompt and persist the results.
+
+    Each line in ``output_path`` will contain a JSON object with keys
+    ``prompt`` and ``sample``.
+    """
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with path.open("w", encoding="utf-8") as f:
+        for prompt in prompts:
+            for _ in range(num_samples):
+                sample = llm(prompt, temperature=temperature)
+                json.dump({"prompt": prompt, "sample": sample}, f, ensure_ascii=False)
+                f.write("\n")
+

--- a/tests/test_sampling_generator.py
+++ b/tests/test_sampling_generator.py
@@ -1,0 +1,41 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from sampling.generator import generate_samples
+
+
+class StubLLM:
+    def __init__(self):
+        self.calls: list[tuple[str, float]] = []
+
+    def __call__(self, prompt: str, *, temperature: float) -> str:
+        self.calls.append((prompt, temperature))
+        return f"sample-{len(self.calls)}"
+
+
+def test_sampling_deterministic(tmp_path: Path):
+    prompts = ["Hello", "World"]
+    out_file = tmp_path / "samples.jsonl"
+    llm = StubLLM()
+
+    generate_samples(llm, prompts, out_file, num_samples=2, temperature=0.3)
+
+    assert len(llm.calls) == 4
+    assert all(t == 0.3 for _, t in llm.calls)
+
+    lines = out_file.read_text().splitlines()
+    assert len(lines) == 4
+    records = [json.loads(line) for line in lines]
+    assert [r["prompt"] for r in records] == ["Hello", "Hello", "World", "World"]
+    assert [r["sample"] for r in records] == [
+        "sample-1",
+        "sample-2",
+        "sample-3",
+        "sample-4",
+    ]
+


### PR DESCRIPTION
## Summary
- add `sampling.generator` module to collect multiple LLM samples with configurable temperature
- save prompt/sample pairs in JSONL for reproducibility
- test sampling using a stubbed LLM to ensure deterministic call counts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895c2ed7c68832586f3bec35aeba55d