### PR TITLE
Integrate OpenAI LLM client for sampling and prompt evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ optionally change the number of evaluated examples with ``--limit``:
 python run_experiments.py --metrics ngram mqag nli --limit 25
 ```
 
+## LLM configuration
+
+Some features such as sample generation (`--resample`) and the `prompt` metric
+require access to an external language model.  The code uses OpenAI's Chat
+Completions API and expects the API key to be available via the
+`OPENAI_API_KEY` environment variable.  The model can be selected with
+`--llm-model`:
+
+```bash
+export OPENAI_API_KEY=sk-YOUR_KEY
+python run_experiments.py --metrics prompt --llm-model gpt-3.5-turbo
+```
+
+The same model is reused for both sample generation and Yes/No judgements.  The
+`--temperature` flag controls sampling temperature.
+
 ## Running tests
 
 ```bash

--- a/sampling/generator.py
+++ b/sampling/generator.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 from pathlib import Path
 import json
 from typing import Iterable, Protocol
+import os
+import time
+
+from openai import OpenAI, RateLimitError
 
 
 class LLM(Protocol):
@@ -11,6 +15,66 @@ class LLM(Protocol):
 
     def __call__(self, prompt: str, *, temperature: float) -> str:  # pragma: no cover - interface
         """Generate a completion for ``prompt``."""
+
+
+class OpenAIChatLLM:
+    """Simple OpenAI Chat Completions client with caching and retries.
+
+    The class reads the API key from the ``OPENAI_API_KEY`` environment
+    variable and uses a small in-memory cache to avoid repeat requests for
+    identical prompts.  It exposes ``ask_yes_no`` for convenience when a
+    Yes/No judgement is required.
+    """
+
+    def __init__(
+        self,
+        model: str = "gpt-3.5-turbo",
+        max_retries: int = 3,
+        retry_wait: float = 1.0,
+    ) -> None:
+        self.model = model
+        self.max_retries = max_retries
+        self.retry_wait = retry_wait
+        self._client: OpenAI | None = None
+        # cache keyed by (prompt, temperature)
+        self._cache: dict[tuple[str, float], str] = {}
+
+    # -- internal ---------------------------------------------------------
+    def _ensure_client(self) -> OpenAI:
+        if self._client is None:
+            api_key = os.getenv("OPENAI_API_KEY")
+            if not api_key:
+                raise RuntimeError("OPENAI_API_KEY environment variable not set")
+            self._client = OpenAI(api_key=api_key)
+        return self._client
+
+    # -- public -----------------------------------------------------------
+    def __call__(self, prompt: str, *, temperature: float) -> str:  # pragma: no cover - network
+        key = (prompt, temperature)
+        if key in self._cache:
+            return self._cache[key]
+
+        client = self._ensure_client()
+        for attempt in range(self.max_retries):
+            try:
+                res = client.chat.completions.create(
+                    model=self.model,
+                    messages=[{"role": "user", "content": prompt}],
+                    temperature=temperature,
+                )
+                text = res.choices[0].message.content or ""
+                self._cache[key] = text
+                return text
+            except RateLimitError:
+                time.sleep(self.retry_wait * (2**attempt))
+        raise RuntimeError("OpenAI API request failed after retries")
+
+    def ask_yes_no(self, context: str, sentence: str) -> str:  # pragma: no cover - network
+        prompt = (
+            f"Context: {context}\nSentence: {sentence}\n"
+            "Is the sentence supported by the context above?\nAnswer Yes or No:"
+        )
+        return self(prompt, temperature=0.0)
 
 
 def generate_samples(


### PR DESCRIPTION
## Summary
- add `OpenAIChatLLM` with retry and caching support
- use shared OpenAI client in `run_experiments.py` for sampling and Yes/No prompt metric
- document API key and model configuration in README

## Testing
- `pytest -q`