### PR TITLE
Update dataset loader for WikiBio hallucination

### DIFF
--- a/data/utils.py
+++ b/data/utils.py
@@ -7,7 +7,7 @@ from typing import Union
 
 from datasets import Dataset, load_dataset
 
-DATASET_NAME = "hallucinations/wikibio"
+DATASET_NAME = "potsawee/wiki_bio_gpt3_hallucination"
 DEFAULT_CACHE_DIR = Path.home() / ".cache" / "selfcheckgpt"
 
 
@@ -40,3 +40,12 @@ def _validate_dataset(dataset: Dataset) -> None:
         raise ValueError("Loaded dataset split is empty")
     if not dataset.column_names:
         raise ValueError("Dataset has no columns")
+
+    required_columns = {
+        "gpt3_sentences",
+        "gpt3_text_samples",
+        "annotation",
+    }
+    missing = required_columns.difference(dataset.column_names)
+    if missing:
+        raise ValueError(f"Dataset missing required columns: {sorted(missing)}")

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -22,3 +22,5 @@ def test_wikibio_dataset_loads(tmp_path):
     except Exception as exc:  # pragma: no cover - network failure
         pytest.skip(f"dataset download failed: {exc}")
     assert len(ds) == 1
+    required = {"gpt3_sentences", "gpt3_text_samples", "annotation"}
+    assert required.issubset(ds.column_names)


### PR DESCRIPTION
## Summary
- update dataset source to `potsawee/wiki_bio_gpt3_hallucination`
- validate required fields `gpt3_sentences`, `gpt3_text_samples`, and `annotation`
- extend tests to check for required dataset columns

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897149419808325b41cde8cda48ccc5