### PR TITLE
Add paper configuration defaults and combiner cross-validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,21 @@ the train, validation and test splits sequentially, storing results for
 each split in a separate subdirectory inside ``--output-dir``:
 
 ```bash
-python run_experiments.py --split all --metrics all --sample-count 5
+python run_experiments.py --split all --metrics all --sample-count 20
 ```
 
 The ``--sample-count`` flag controls how many sampled passages per
 prompt are used.  When ``--resample`` is given this number of samples is
 regenerated with the lightweight sampling pipeline.  Otherwise the
 pre‑computed samples in the dataset are truncated to the requested count.
+By default the script now follows the paper and uses 20 samples per
+prompt.
+
+The logistic‑regression combiner can optionally be evaluated with
+stratified ``k``‑fold cross‑validation via ``--cv-folds`` (default: 5).
+To mirror the exact settings from the paper, pass ``--paper-config``
+which enables resampling, sets ``--sample-count`` to 20 and applies the
+original top‑k/top‑p cut‑offs.
 
 Every run writes a ``summary.csv`` file and generates precision/recall
 and calibration plots for each metric, reproducing the statistics

--- a/tests/test_run_experiments_integration.py
+++ b/tests/test_run_experiments_integration.py
@@ -160,3 +160,119 @@ def test_run_experiments_passes_sampling_params(tmp_path, monkeypatch):
         "top_p": 0.9,
         "deterministic": True,
     }
+
+
+def test_run_experiments_paper_config(tmp_path, monkeypatch):
+    ds = Dataset.from_dict(
+        {
+            "gpt3_sentences": [["Paris is in France."]],
+            "annotation": [["accurate"]],
+        }
+    )
+
+    monkeypatch.setattr(run_experiments, "load_wikibio_hallucination", lambda split="test": ds)
+
+    captured = {}
+
+    def fake_generate(
+        llm,
+        prompts,
+        output_path,
+        *,
+        num_samples,
+        temperature,
+        top_k,
+        top_p,
+        deterministic,
+        cache_dir=None,
+    ):
+        captured.update(
+            {
+                "num_samples": num_samples,
+                "temperature": temperature,
+                "top_k": top_k,
+                "top_p": top_p,
+                "deterministic": deterministic,
+            }
+        )
+        with Path(output_path).open("w", encoding="utf-8") as f:
+            for p in prompts:
+                json.dump({"prompt": p, "sample": "s"}, f)
+                f.write("\n")
+
+    monkeypatch.setattr(run_experiments, "generate_samples", fake_generate)
+
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_experiments.py",
+            "--metrics",
+            "ngram",
+            "--limit",
+            "1",
+            "--output-dir",
+            str(out_dir),
+            "--paper-config",
+        ],
+    )
+
+    run_experiments.main()
+
+    assert captured == {
+        "num_samples": 20,
+        "temperature": 0.7,
+        "top_k": 50,
+        "top_p": 0.95,
+        "deterministic": False,
+    }
+
+
+def test_run_experiments_combiner_cv(tmp_path, monkeypatch):
+    # create dataset with 10 examples and alternating labels
+    sentences = [[f"S{i}"] for i in range(10)]
+    samples = [[f"S{i}"] for i in range(10)]
+    annotations = [["accurate"] if i % 2 == 0 else ["inaccurate"] for i in range(10)]
+    ds = Dataset.from_dict(
+        {
+            "gpt3_sentences": sentences,
+            "gpt3_text_samples": samples,
+            "annotation": annotations,
+        }
+    )
+
+    monkeypatch.setattr(run_experiments, "load_wikibio_hallucination", lambda split="test": ds)
+
+    class DummyMetric:
+        def __init__(self, value):
+            self.value = value
+
+        def predict(self, sentences, samples):
+            return [self.value for _ in sentences]
+
+    run_experiments.METRICS["m1"] = lambda: DummyMetric(0.1)
+    run_experiments.METRICS["m2"] = lambda: DummyMetric(0.9)
+
+    out_dir = tmp_path / "out"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_experiments.py",
+            "--metrics",
+            "m1",
+            "m2",
+            "--limit",
+            "10",
+            "--output-dir",
+            str(out_dir),
+        ],
+    )
+
+    run_experiments.main()
+
+    summary = out_dir / "summary.csv"
+    assert summary.exists()
+    content = summary.read_text()
+    assert "combined" in content


### PR DESCRIPTION
## Summary
- Raise default sample generation to 20 and auto-resample when top‑k/top‑p are set
- Add `--cv-folds` and stratified cross-validation for the logistic regression combiner
- Provide `--paper-config` shortcut and update docs/tests for paper settings

## Testing
- `pytest -q`