### PR TITLE
Add explicit dataset split arguments and save combiner weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ optionally change the number of evaluated examples with ``--limit``:
 python run_experiments.py --metrics ngram mqag nli --limit 25
 ```
 
-Use ``--split`` to select dataset partitions.  Passing ``all`` evaluates
-the train, validation and test splits sequentially, storing results for
-each split in a separate subdirectory inside ``--output-dir``:
+Use ``--train-split``, ``--val-split`` and ``--test-split`` to select dataset
+partitions for training the combiner, optional validation, and final
+evaluation.  Splits accept the usual Hugging Face slicing syntax:
 
 ```bash
-python run_experiments.py --split all --metrics all --sample-count 20
+python run_experiments.py --train-split train[:1000] --val-split validation[:200] --test-split test --metrics all --sample-count 20
 ```
 
 The ``--sample-count`` flag controls how many sampled passages per
@@ -64,11 +64,10 @@ pre‑computed samples in the dataset are truncated to the requested count.
 By default the script now follows the paper and uses 20 samples per
 prompt.
 
-The logistic‑regression combiner can optionally be evaluated with
-stratified ``k``‑fold cross‑validation via ``--cv-folds`` (default: 5).
-To mirror the exact settings from the paper, pass ``--paper-config``
-which enables resampling, sets ``--sample-count`` to 20 and applies the
-original top‑k/top‑p cut‑offs.
+The logistic‑regression combiner is trained on the specified training
+split and evaluated on the test split.  To mirror the exact settings
+from the paper, pass ``--paper-config`` which enables resampling, sets
+``--sample-count`` to 20 and applies the original top‑k/top‑p cut‑offs.
 
 Every run writes a ``summary.csv`` file and generates precision/recall
 and calibration plots for each metric, reproducing the statistics

--- a/tests/test_run_experiments_integration.py
+++ b/tests/test_run_experiments_integration.py
@@ -17,7 +17,10 @@ def test_run_experiments_tiny(tmp_path, monkeypatch):
         }
     )
 
+    seen_splits = []
+
     def fake_loader(split="test"):
+        seen_splits.append(split)
         return ds
 
     monkeypatch.setattr(run_experiments, "load_wikibio_hallucination", fake_loader)
@@ -34,6 +37,12 @@ def test_run_experiments_tiny(tmp_path, monkeypatch):
             "1",
             "--output-dir",
             str(out_dir),
+            "--train-split",
+            "train[:1]",
+            "--val-split",
+            "validation[:1]",
+            "--test-split",
+            "test[:1]",
         ],
     )
     run_experiments.main()
@@ -42,8 +51,10 @@ def test_run_experiments_tiny(tmp_path, monkeypatch):
     assert summary.exists()
     assert (out_dir / "ngram_pr.png").exists()
     assert (out_dir / "ngram_calibration.png").exists()
+    assert (out_dir / "combiner.pt").exists()
     content = summary.read_text()
     assert "ngram" in content
+    assert seen_splits == ["train[:1]", "validation[:1]", "test[:1]"]
 
 
 def test_run_experiments_temperature_sweep(tmp_path, monkeypatch):
@@ -229,7 +240,7 @@ def test_run_experiments_paper_config(tmp_path, monkeypatch):
     }
 
 
-def test_run_experiments_combiner_cv(tmp_path, monkeypatch):
+def test_run_experiments_combiner(tmp_path, monkeypatch):
     # create dataset with 10 examples and alternating labels
     sentences = [[f"S{i}"] for i in range(10)]
     samples = [[f"S{i}"] for i in range(10)]
@@ -267,6 +278,10 @@ def test_run_experiments_combiner_cv(tmp_path, monkeypatch):
             "10",
             "--output-dir",
             str(out_dir),
+            "--train-split",
+            "train",
+            "--test-split",
+            "test",
         ],
     )
 


### PR DESCRIPTION
## Summary
- allow `run_experiments.py` to load explicit train/validation/test splits via new CLI arguments
- train combiner on train split (optionally using validation for calibration), evaluate on test split, and save combiner weights
- extend integration tests to cover new split options and ensure combiner weights are written

## Testing
- `pytest -q`