### PR TITLE
Refactor MQAG predict to use probability distances and answerability thresholds

### DIFF
--- a/selfcheckgpt/utils.py
+++ b/selfcheckgpt/utils.py
@@ -1,0 +1,36 @@
+"""Minimal stubs for the original :mod:`selfcheckgpt` utilities.
+
+This project only relies on a tiny subset of the real library.  The
+functions defined here provide the interfaces expected by
+``selfcheck_metrics`` so that the tests can run without the heavy
+dependencies of the original project.  They intentionally implement only
+the minimal behaviour required by the tests; the generation and
+answering helpers merely raise :class:`NotImplementedError` if invoked.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class MQAGConfig:
+    """Model names used by the MQAG metric.
+
+    The real project stores default HuggingFace model identifiers here.
+    For the purposes of the tests we simply keep placeholder strings.
+    """
+
+    generation1_squad: str = "g1"
+    generation2: str = "g2"
+    answering: str = "qa"
+
+
+def _not_impl(*args, **kwargs):  # pragma: no cover - defensive stub
+    raise NotImplementedError("This stub does not implement the full logic")
+
+
+prepare_qa_input = _not_impl
+prepare_distractor_input = _not_impl
+prepare_answering_input = _not_impl
+


### PR DESCRIPTION
## Summary
- add `get_prob_distances` utility to compute KL, counting, Hellinger and total variation distances
- extend MQAG to load answerability model, generate MC questions and compute probability-based disagreement with calibrated thresholds
- include lightweight `selfcheckgpt` stub and adjust tests for new probability-distance API

## Testing
- `pytest -q`