### PR TITLE
Add classifier-based answerability to MQAG metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,32 @@ classes for five scoring strategies:
 * **NLI** – entailment check using a pretrained NLI model.
 * **LLM Prompt** – ask an external model whether a sentence is supported.
 
+## Quick MQAG example
+
+Run the full MQAG pipeline with real HuggingFace models:
+
+```python
+from selfcheck_metrics import SelfCheckMQAG
+
+sentences = ["Paris is the capital of Germany."]
+samples = [
+    "Berlin is the capital of Germany.",
+    "Paris is the capital of France.",
+]
+
+mqag = SelfCheckMQAG(
+    g1_model="potsawee/t5-base-squad-qg",
+    g2_model="potsawee/t5-base-distractor-generation",
+    qa_model="potsawee/longformer-large-4096-mc-squad2",
+    answer_model="potsawee/longformer-large-4096-answerable-squad2",
+)
+
+scores, answerability = mqag.predict(sentences, samples)
+print(scores[0], answerability[0])
+```
+
+The first call downloads the model weights and may take a moment.
+
 The `run_experiments.py` script can evaluate any of the simplified
 metrics on the WikiBio hallucination dataset.  It mirrors the evaluation
 loop of the original project but uses light‑weight stand‑ins so that the

--- a/tests/test_selfcheck_metrics.py
+++ b/tests/test_selfcheck_metrics.py
@@ -365,7 +365,7 @@ def test_mqag_probability_distance():
         sents, samples, metric="counting", disagreement_threshold=0.5
     )
     assert math.isclose(scores[0], 0.5)
-    assert ans_stats == [[1.0]]
+    assert ans_stats == [[0.9]]
     assert metric.last_answerability == ans_stats
     assert metric.last_disagreement == scores
 
@@ -391,9 +391,9 @@ def test_mqag_answerability_filter():
         sents, samples, metric="counting", disagreement_threshold=0.5
     )
     assert math.isclose(scores[0], 0.5)
-    assert ans_stats == [[0.0]]
-    assert metric.last_unanswerable == [1.0]
-    assert math.isclose(metric.avg_unanswerable, 1.0)
+    assert ans_stats == [[0.3]]
+    assert metric.last_unanswerable == [0.7]
+    assert math.isclose(metric.avg_unanswerable, 0.7)
 
 
 def test_mqag_parity_with_paper():


### PR DESCRIPTION
## Summary
- Document MQAG configuration parameters and device options
- Use utilities and answerability classifier logits in MQAG generation pipeline
- Add MQAG usage example with real models to README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68985a2a8f0c8325a307fcc71772ba91