### PR TITLE
Ensure MQAG uses paper models by default

### DIFF
--- a/selfcheck_metrics.py
+++ b/selfcheck_metrics.py
@@ -270,7 +270,7 @@ class SelfCheckMQAG:
             g1_model = g1_model or MQAGConfig.generation1_squad
             g2_model = g2_model or MQAGConfig.generation2
             qa_model = qa_model or MQAGConfig.answering
-            answer_model = answer_model or "potsawee/longformer-large-4096-answerable-squad2"
+            answer_model = answer_model or MQAGConfig.answerable
 
             self.g1_tokenizer = AutoTokenizer.from_pretrained(g1_model)
             self.g1_model = AutoModelForSeq2SeqLM.from_pretrained(g1_model)

--- a/selfcheckgpt/utils.py
+++ b/selfcheckgpt/utils.py
@@ -17,13 +17,19 @@ from dataclasses import dataclass
 class MQAGConfig:
     """Model names used by the MQAG metric.
 
-    The real project stores default HuggingFace model identifiers here.
-    For the purposes of the tests we simply keep placeholder strings.
+    These defaults mirror the identifiers cited in the original
+    SelfCheckGPT paper and point to publicly available HuggingFace
+    checkpoints.  They are used when no explicit model names are provided
+    to :class:`selfcheck_metrics.SelfCheckMQAG`.
     """
 
-    generation1_squad: str = "g1"
-    generation2: str = "g2"
-    answering: str = "qa"
+    # First and second question generation models
+    generation1_squad: str = "potsawee/t5-base-squad-qg"
+    generation2: str = "potsawee/t5-base-distractor-generation"
+    # Multiple-choice answerer
+    answering: str = "potsawee/longformer-large-4096-mc-squad2"
+    # Answerability classifier
+    answerable: str = "potsawee/longformer-large-4096-answerable-squad2"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- default MQAG config now points to the four HuggingFace checkpoints cited in the SelfCheckGPT paper
- SelfCheckMQAG pulls its answerability model from this config, keeping all heavy models on GPU when available

## Testing
- `TRANSFORMERS_OFFLINE=1 pytest`
- `bash scripts/setup_gpu_env.sh` *(fails to fully complete due to environment but begins downloading packages)*


------
https://chatgpt.com/codex/tasks/task_e_68989f2ad14c83258cc96ec8ae99dba0