### PR TITLE
Add regularization and early stopping to combiner

### DIFF
--- a/selfcheck_combiner.py
+++ b/selfcheck_combiner.py
@@ -14,19 +14,25 @@ class SelfCheckCombiner:
 
     Parameters
     ----------
-    lr: float, optional
+    lr:
         Learning rate for SGD.
-    epochs: int, optional
-        Number of passes over the training data.
-    device: str, optional
-        Device to run training on (``"cpu"`` or ``"cuda"``).  If ``None`` the
-        device is automatically chosen based on availability.
-    seed: int, optional
+    epochs:
+        Maximum number of passes over the training data.
+    l2:
+        L2 regularisation strength (implemented via weight decay).
+    patience:
+        Number of epochs with no improvement on the validation loss before
+        stopping early.  ``0`` disables early stopping.
+    device:
+        Device to run training on.
+    seed:
         Random seed for deterministic initialisation.
     """
 
     lr: float = 0.1
     epochs: int = 100
+    l2: float = 0.0
+    patience: int = 0
     device: str | None = None
     seed: int = 0
 
@@ -36,9 +42,21 @@ class SelfCheckCombiner:
         if self.device is None:
             self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self._model = None
+        self.trained_epochs = 0
 
-    def fit(self, X: Iterable[Iterable[float]], y: Iterable[int]) -> "SelfCheckCombiner":
-        """Fit the combiner on ``X`` and ``y``."""
+    def fit(
+        self,
+        X: Iterable[Iterable[float]],
+        y: Iterable[int],
+        *,
+        X_val: Iterable[Iterable[float]] | None = None,
+        y_val: Iterable[int] | None = None,
+    ) -> "SelfCheckCombiner":
+        """Fit the combiner on ``X`` and ``y``.
+
+        ``X_val`` and ``y_val`` optionally provide a validation split for
+        early stopping.
+        """
 
         import torch
         from torch import nn, optim
@@ -48,17 +66,46 @@ class SelfCheckCombiner:
         X_t = torch.tensor(np.array(list(X)), dtype=torch.float32, device=self.device)
         y_t = torch.tensor(np.array(list(y)), dtype=torch.float32, device=self.device).unsqueeze(1)
 
+        X_val_t = None
+        y_val_t = None
+        if X_val is not None and y_val is not None and self.patience > 0:
+            X_val_t = torch.tensor(np.array(list(X_val)), dtype=torch.float32, device=self.device)
+            y_val_t = torch.tensor(np.array(list(y_val)), dtype=torch.float32, device=self.device).unsqueeze(1)
+
         n_features = X_t.shape[1]
         model = nn.Linear(n_features, 1).to(self.device)
-        opt = optim.SGD(model.parameters(), lr=self.lr)
+        opt = optim.SGD(model.parameters(), lr=self.lr, weight_decay=self.l2)
         loss_fn = nn.BCEWithLogitsLoss()
 
-        for _ in range(self.epochs):
+        best_state = None
+        best_loss = float("inf")
+        epochs_run = 0
+        patience_left = self.patience
+
+        for epoch in range(self.epochs):
             opt.zero_grad()
             logits = model(X_t)
             loss = loss_fn(logits, y_t)
             loss.backward()
             opt.step()
+
+            epochs_run = epoch + 1
+
+            if X_val_t is not None:
+                with torch.no_grad():
+                    val_loss = loss_fn(model(X_val_t), y_val_t).item()
+                if val_loss < best_loss - 1e-6:
+                    best_loss = val_loss
+                    best_state = {k: v.clone() for k, v in model.state_dict().items()}
+                    patience_left = self.patience
+                else:
+                    patience_left -= 1
+                    if patience_left <= 0:
+                        break
+
+        self.trained_epochs = epochs_run
+        if best_state is not None:
+            model.load_state_dict(best_state)
 
         self._model = model
         return self
@@ -77,3 +124,4 @@ class SelfCheckCombiner:
         with torch.no_grad():
             probs = torch.sigmoid(self._model(X_t)).squeeze().cpu().numpy()
         return probs.tolist()
+

--- a/tests/test_selfcheck_combiner.py
+++ b/tests/test_selfcheck_combiner.py
@@ -28,3 +28,38 @@ def test_combiner_deterministic():
 
     assert np.allclose(preds1, preds2)
     assert preds1[0] < preds1[1]
+
+
+def test_combiner_l2_changes_predictions():
+    X = np.array(
+        [
+            [0.1, 0.2],
+            [0.9, 0.8],
+            [0.2, 0.3],
+            [0.8, 0.7],
+        ]
+    )
+    y = np.array([0, 1, 0, 1])
+
+    comb_no_reg = SelfCheckCombiner(epochs=50, lr=0.5, device="cpu", seed=0, l2=0.0)
+    comb_no_reg.fit(X, y)
+    preds_no_reg = comb_no_reg.predict(X)
+
+    comb_reg = SelfCheckCombiner(epochs=50, lr=0.5, device="cpu", seed=0, l2=1.0)
+    comb_reg.fit(X, y)
+    preds_reg = comb_reg.predict(X)
+
+    assert not np.allclose(preds_no_reg, preds_reg)
+
+
+def test_combiner_early_stopping():
+    X = np.zeros((4, 2), dtype=float)
+    y = np.array([0, 1, 0, 1])
+    X_val = np.zeros((2, 2), dtype=float)
+    y_val = np.array([0, 1])
+
+    comb = SelfCheckCombiner(epochs=50, lr=0.5, device="cpu", patience=2)
+    comb.fit(X, y, X_val=X_val, y_val=y_val)
+
+    # With constant validation loss early stopping should trigger before all epochs
+    assert comb.trained_epochs < 50


### PR DESCRIPTION
## Summary
- support L2 regularization and validation-based early stopping in `SelfCheckCombiner`
- allow configuring combiner regularization and patience via CLI flags
- apply L2 and early stopping under `--paper-config` and persist combiner weights

## Testing
- `pytest -q`